### PR TITLE
Fix issue when adding tags to users 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+default: test
+
+test:
+	bundle exec rake plugin:spec["discourse-mailchimp-list"]

--- a/app/jobs/mailchimp_subscription.rb
+++ b/app/jobs/mailchimp_subscription.rb
@@ -2,38 +2,54 @@
 module Jobs
   class MailchimpSubscription < ::Jobs::Base
     def execute(args)
-      email = args[:email]
-      name = args[:name]
-      list_id = args[:list_id]
-      api_key = args[:api_key]
+      api_key = SiteSetting.discourse_mailchimp_api_key
+      list_id = SiteSetting.discourse_mailchimp_list_id
       debug = !!args[:debug]
       tags = args[:tags] || []
 
+      return unless api_key && list_id
+
+      # Find user
+      user_id = args[:user_id]
+      user = User.find(user_id)
+      email = user.email
+      name = user.name
+
       # init Gibbon
       gibbon = Gibbon::Request.new(api_key: api_key, debug: debug)
-      gibbon_list = gibbon.lists(list_id)
 
       # naive approach to split full name in first and last
       first_name, *last_name = name.split(' ')
       last_name = last_name.join(' ')
 
+      ip_signup = user.registration_ip_address.to_s
       email_digest = Digest::MD5.hexdigest(email.downcase)
 
+      # Get phone number
+      # TODO: Move this Discourse Settings, so it can be used by others
+      # Right now it is specific to our implementation
+      phone_number_field = UserField.find_by(name: "Phone Number")
+      phone_number = user.user_fields.fetch(phone_number_field.id.to_s, "") if phone_number_field
+
       # add user to list
-      gibbon_list
+      gibbon
+        .lists(list_id)
         .members(email_digest)
         .upsert(body: {
           email_address: email,
           status: "subscribed",
+          ip_signup: ip_signup,
           merge_fields: {
             FNAME: first_name,
             LNAME: last_name,
+            PHONE: phone_number,
           }
         })
 
       # add tags to user
       if tags.any?
-        gibbon_list
+        gibbon
+          .lists(list_id)
           .members(email_digest)
           .tags
           .create(body: {

--- a/plugin.rb
+++ b/plugin.rb
@@ -16,17 +16,11 @@ after_initialize do
   load File.expand_path('../app/jobs/mailchimp_subscription.rb', __FILE__)
 
   DiscourseEvent.on(:user_created) do |user|
-    api_key = SiteSetting.discourse_mailchimp_api_key
-    list_id = SiteSetting.discourse_mailchimp_list_id
-
-    next unless SiteSetting.discourse_mailchimp_list_enabled && api_key && list_id
+    next unless SiteSetting.discourse_mailchimp_list_enabled
 
     # get arguments for job
     args = {
-      email: user.email,
-      name: user.name,
-      list_id: list_id,
-      api_key: api_key,
+      user_id: user.id,
       tags: [{ name: "discourse", status: "active" }],
       debug: true
     }

--- a/plugin.rb
+++ b/plugin.rb
@@ -10,7 +10,7 @@ enabled_site_setting :discourse_mailchimp_list_enabled
 
 PLUGIN_NAME ||= 'DiscourseMailchimpList'
 
-gem 'gibbon', '3.3.3'
+gem 'gibbon', '3.3.4'
 
 after_initialize do
   load File.expand_path('../app/jobs/mailchimp_subscription.rb', __FILE__)

--- a/spec/jobs/mailchimp_subscription_spec.rb
+++ b/spec/jobs/mailchimp_subscription_spec.rb
@@ -2,73 +2,81 @@
 require 'rails_helper'
 
 describe Jobs::MailchimpSubscription do
-  it "calls upsert with the md5 hashed email" do
-    md5_email = Digest::MD5.hexdigest('test@example.com')
-    args = {
-      email: 'test@example.com',
-      name: 'test user',
-      list_id: '1234567890',
-      api_key: 'testapikeytestapikeytestapikey0c-us8',
-    }
+  describe("#execute") do
+    before do
+      phone_user_field = Fabricate(:user_field, name: "Phone Number")
+      @user = Fabricate(:user,
+        email: "test@example.com",
+        name: "Bruce Wayne",
+        custom_fields: { "user_field_#{phone_user_field.id}": "800123123123" }
+      )
 
-    # stub members request
-    Sidekiq::Testing.fake! do
-      stub_request(:put, "https://us8.api.mailchimp.com/3.0/lists/1234567890/members/55502f40dc8b7c769880b10874abc9d0").
-        with(
-        body: "{\"email_address\":\"test@example.com\",\"status\":\"subscribed\",\"merge_fields\":{\"FNAME\":\"test\",\"LNAME\":\"user\"}}",
-        headers: {
-        'Accept' => '*/*',
-        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Authorization' => 'Basic YXBpa2V5OnRlc3RhcGlrZXl0ZXN0YXBpa2V5dGVzdGFwaWtleTBjLXVzOA==',
-        'Content-Type' => 'application/json',
-        'User-Agent' => 'Faraday v0.17.3'
-        }).
-        to_return(status: 200, body: "", headers: {})
-
-      Jobs::MailchimpSubscription.new.execute(args)
+      SiteSetting.discourse_mailchimp_api_key = "testapikeytestapikeytestapikey0c-us8"
+      SiteSetting.discourse_mailchimp_list_id = "1234567890"
     end
-  end
 
-  it "calls tags when passing tags" do
-    md5_email = Digest::MD5.hexdigest('test@example.com')
-    args = {
-      email: 'test@example.com',
-      name: 'test user',
-      list_id: '1234567890',
-      api_key: 'testapikeytestapikeytestapikey0c-us8',
-      tags: [{ name: "discourse", status: "active" }],
-    }
+    it "calls upsert with the md5 hashed email" do
+      md5_email = Digest::MD5.hexdigest(@user.email)
+      args = {
+        user_id: @user.id,
+        debug: true
+      }
 
-    Sidekiq::Testing.fake! do
-      gibbon = Gibbon::Request.new(api_key: args[:api_key])
+      Sidekiq::Testing.fake! do
+        # stub members request
+        stub_request(:put, "https://us8.api.mailchimp.com/3.0/lists/1234567890/members/55502f40dc8b7c769880b10874abc9d0").
+          with(
+            body: "{\"email_address\":\"test@example.com\",\"status\":\"subscribed\",\"ip_signup\":\"\",\"merge_fields\":{\"FNAME\":\"Bruce\",\"LNAME\":\"Wayne\",\"PHONE\":\"800123123123\"}}",
+            headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'Basic YXBpa2V5OnRlc3RhcGlrZXl0ZXN0YXBpa2V5dGVzdGFwaWtleTBjLXVzOA==',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'Faraday v1.0.1'
+            }).
+          to_return(status: 200, body: "", headers: {})
 
-      # stub members request
-      stub_request(:put, "https://us8.api.mailchimp.com/3.0/lists/1234567890/members/55502f40dc8b7c769880b10874abc9d0").
-        with(
-        body: "{\"email_address\":\"test@example.com\",\"status\":\"subscribed\",\"merge_fields\":{\"FNAME\":\"test\",\"LNAME\":\"user\"}}",
-        headers: {
-        'Accept' => '*/*',
-        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Authorization' => 'Basic YXBpa2V5OnRlc3RhcGlrZXl0ZXN0YXBpa2V5dGVzdGFwaWtleTBjLXVzOA==',
-        'Content-Type' => 'application/json',
-        'User-Agent' => 'Faraday v0.17.3'
-        }).
-        to_return(status: 200, body: "", headers: {})
+          Jobs::MailchimpSubscription.new.execute(args)
+      end
+    end
 
-      # stub tags request
-      stub_request(:post, "https://us8.api.mailchimp.com/3.0/members/55502f40dc8b7c769880b10874abc9d0/tags").
-        with(
-        body: "{\"tags\":[{\"name\":\"discourse\",\"status\":\"active\"}]}",
-        headers: {
-        'Accept' => '*/*',
-        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Authorization' => 'Basic YXBpa2V5OnRlc3RhcGlrZXl0ZXN0YXBpa2V5dGVzdGFwaWtleTBjLXVzOA==',
-        'Content-Type' => 'application/json',
-        'User-Agent' => 'Faraday v0.17.3'
-        }).
-        to_return(status: 200, body: "", headers: {})
+    it "calls tags when passing tags" do
+      md5_email = Digest::MD5.hexdigest(@user.email)
+      args = {
+        user_id: @user.id,
+        debug: true,
+        tags: [{ name: "discourse", status: "active" }],
+      }
 
-      Jobs::MailchimpSubscription.new.execute(args)
+      Sidekiq::Testing.fake! do
+        # stub members request
+        stub_request(:put, "https://us8.api.mailchimp.com/3.0/lists/1234567890/members/55502f40dc8b7c769880b10874abc9d0").
+          with(
+            body: "{\"email_address\":\"test@example.com\",\"status\":\"subscribed\",\"ip_signup\":\"\",\"merge_fields\":{\"FNAME\":\"Bruce\",\"LNAME\":\"Wayne\",\"PHONE\":\"800123123123\"}}",
+            headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'Basic YXBpa2V5OnRlc3RhcGlrZXl0ZXN0YXBpa2V5dGVzdGFwaWtleTBjLXVzOA==',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'Faraday v1.0.1'
+            }).
+          to_return(status: 200, body: "", headers: {})
+
+        # stub tags request
+        stub_request(:post, "https://us8.api.mailchimp.com/3.0/lists/1234567890/members/55502f40dc8b7c769880b10874abc9d0/tags").
+          with(
+            body: "{\"tags\":[{\"name\":\"discourse\",\"status\":\"active\"}]}",
+            headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'Basic YXBpa2V5OnRlc3RhcGlrZXl0ZXN0YXBpa2V5dGVzdGFwaWtleTBjLXVzOA==',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'Faraday v1.0.1'
+            }).
+          to_return(status: 200, body: "", headers: {})
+
+        Jobs::MailchimpSubscription.new.execute(args)
+      end
     end
   end
 end


### PR DESCRIPTION
**What:** Fix issue when adding tags to users.

The issue was caused by trying to reuse the `Gibbon.list`. For some reason, it errors out before doing the request if I tried to reuse the list in the next command. I removed that code and made other small improvements.
 
**Why:** Fixes https://app.asana.com/0/1168997577035609/1176990192479185

**How:**

- Call `gibbon.list` every time we need to use it.
- Pass a `user_id` to pull user information inside the scheduled job.
